### PR TITLE
RFR: Fix homepage styling bleed

### DIFF
--- a/frontend/src/pages/Home.js
+++ b/frontend/src/pages/Home.js
@@ -19,7 +19,7 @@ class Home extends Component {
   render() {
     return (
       <div>
-        <Container>
+        <Container className="homepage">
           <Row>
             <Col id="left">
               <Card className="parent">

--- a/frontend/src/styles/Home.scss
+++ b/frontend/src/styles/Home.scss
@@ -1,32 +1,34 @@
-.card {
-  margin: 30px;
-  padding: 10px;
-}
+.homepage {
+  .card {
+    margin: 30px;
+    padding: 10px;
+  }
 
-.parent {
-  background-color: bisque;
-}
+  .parent {
+    background-color: bisque;
+  }
 
-h1 {
-  margin: 30px;
-}
+  h1 {
+    margin: 30px;
+  }
 
-.button {
-  background-color: #007bff;
-  color: white;
-}
+  .button {
+    background-color: #007bff;
+    color: white;
+  }
 
-.image {
-  width: 100px;
-  height: auto;
-  align-self: center;
-}
+  .image {
+    width: 100px;
+    height: auto;
+    align-self: center;
+  }
 
-.card a span {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  top: 0;
-  left: 0;
-  z-index: 1;
+  .card a span {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    z-index: 1;
+  }
 }


### PR DESCRIPTION
<!--
WELCOME TO OUR PULL REQUEST TEMPLATE! :partyparrot:
Not all sections apply, feel free to delete as appropriate.
-->

## Status: 
<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->
:rocket: Ready

## Deploy link
<!--
cd frontend && now --public
TBA: backend deployment
-->

https://phillyreads-wlqszydpaj.now.sh

## Description
Added specific class selectors for the homepage so there isn't any bleeding into other components.

Related issues: Fixes #103


## Screenshots
<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
