### PR TITLE
RFR: Changed GET quiz result endpoint

### DIFF
--- a/backend/api/views/quiz.py
+++ b/backend/api/views/quiz.py
@@ -86,10 +86,10 @@ def create_quiz():
     )
 
 
-@quiz.route("/<user_id>/quiz_results", methods=["GET"])
-def get_quiz_results(user_id):
+@quiz.route("/quiz_results", methods=["GET"])
+def get_quiz_results():
     try:
-        token_user_id = User.decode_auth_token(request.cookies.get("jwt"))
+        user_id = User.decode_auth_token(request.cookies.get("jwt"))
     except jwt.ExpiredSignatureError:
         return create_response(
             message="Expired token", status=401, data={"status": "fail"}
@@ -98,13 +98,6 @@ def get_quiz_results(user_id):
         return create_response(
             message="Invalid token", status=401, data={"status": "fail"}
         )
-    if int(token_user_id) != int(user_id):  # validate user's identity
-        return create_response(
-            message="Invalid token for selected user",
-            status=401,
-            data={"status": "fail"},
-        )
-
     user = User.query.filter_by(id=user_id).first()
 
     # invalid user


### PR DESCRIPTION
## Status: 
:rocket: Ready

## Description
Removed user_id as a path parameter for the /quiz_results endpoint. Derive user id from the jwt token.

Related issues: fixes #132