### PR TITLE
RFR: Click anywhere in quiz question box

### DIFF
--- a/frontend/src/components/Question.js
+++ b/frontend/src/components/Question.js
@@ -75,7 +75,11 @@ class Question extends Component {
     );
 
     return (
-      <ListGroupItem key={i} color={this.returnColor(i)}>
+      <ListGroupItem
+        key={i}
+        onClick={() => this.props.setQuestionProps({ selectedAnswer: i })}
+        color={this.returnColor(i)}
+      >
         <FormGroup check>
           <Label check>
             {input}

--- a/frontend/src/styles/QuizPage.scss
+++ b/frontend/src/styles/QuizPage.scss
@@ -11,6 +11,9 @@
     float: right;
   }
 
+  .list-group-item:hover {
+    background-color: rgba(255, 255, 255, 0.95);
+  }
   .next-button {
     float: right;
     outline: none;


### PR DESCRIPTION
<!--
WELCOME TO OUR PULL REQUEST TEMPLATE! :partyparrot:
Not all sections apply, feel free to delete as appropriate.
-->

## Status: 
<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->
🚀 

## Deploy link
<!--
cd frontend && now --public
TBA: backend deployment
-->


## Description
Added light highlighting around the box that's being hovered over, and allowed the user to click anywhere in box.

Related issues: #122
Related PRs: #<number>


## Todos
<!--
- [ ] Tests
- [ ] Documentation
-->


## Screenshots
<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
![image](https://user-images.githubusercontent.com/8664074/50138185-5c981780-0263-11e9-96a1-2bceb1054871.png)
