### PR TITLE
Windows 10 environment script & config (#262)

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -24,8 +24,7 @@ services:
       - .:/app
     depends_on:
       - postgres
-    entrypoint: 
-      - /app/docker_script.sh
+    entrypoint: ['bash', '/app/docker_script.sh']
 
 volumes:
   flask-app-db:

--- a/backend/reset_db_with_sample_data.sh
+++ b/backend/reset_db_with_sample_data.sh
@@ -12,3 +12,4 @@ echo "DONE"
 echo "run server with:"
 echo "pipenv run python manage.py runserver"
 kill $SERVER_PID
+$SHELL


### PR DESCRIPTION
## Status: 
:construction: In development

## Description
PR to introduce changes to 2 config & script files to make them work in the Windows 10 environment. Assuming the contributor has installed docker desktop for Windows, python, pipenv, and git bash, the two tweaks are:
/backend/docker-compose.yml: altered the app service entrypoint to specify bash as the shell
/backend/reset_db_with_sample_data.sh: appended a line to keep the bash shell open after executing the script so the developer can see the script output (git bash window seems to close after execution, regardless of exit code)

Related issues: #262


## Todos
- [X ] Documentation: If these altered files do not work in the Mac or Unix environments, then they will need to be saved as similarly-yet-distinctly-named files and a brief doc written about how to use them/maybe the prerequisites
