### PR TITLE
add info about windows local setup

### DIFF
--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -42,3 +42,8 @@ If you run into issues with the docker process you can review logs that will mak
 ```
 docker-compose -f docker-compose-dev.yml logs
 ```
+
+#### Note to Windows users
+Everything should work well for you using docker for windows, but you may run into issues with the `/backend/docker_script.sh` script because dos may not be able to read it and it will result in the build process failing.
+
+To solve this issue use [dos2unix](http://dos2unix.sourceforge.net/) to convert the file to a dos friendly format.


### PR DESCRIPTION
:rocket: Ready

## Description
This PR provides some additional info to Windows users regarding getting their local development environment set up. Since we decided to go with docker the process should be fairly painless, but there may be some issues with reading the `.sh` files that are used to set up the backend. This adds information to the `local_setup.md` guide on how to resolve the potential issues.


Related issues: #262 #263 

