### PR TITLE
Conditionally render pagination buttons based on current page

### DIFF
--- a/frontend/src/components/catalog/Catalog.js
+++ b/frontend/src/components/catalog/Catalog.js
@@ -70,19 +70,33 @@ class Catalog extends Component {
     ));
   };
 
+  currentPageIsFirstPage = () => {
+    return this.state.page === 1;
+  };
+
   renderPaginationPrev = () => {
+    // hide when on first page
     return (
-      <PaginationItem>
-        <PaginationLink previous onClick={() => this.changePagePrev()} />
-      </PaginationItem>
+      !this.currentPageIsFirstPage() && (
+        <PaginationItem>
+          <PaginationLink previous onClick={() => this.changePagePrev()} />
+        </PaginationItem>
+      )
     );
   };
 
+  currentPageIsLastPage = () => {
+    return this.getNumPageItems() === this.state.page;
+  };
+
   renderPaginationNext = () => {
+    // hide when on last page
     return (
-      <PaginationItem>
-        <PaginationLink next onClick={() => this.changePageNext()} />
-      </PaginationItem>
+      !this.currentPageIsLastPage() && (
+        <PaginationItem>
+          <PaginationLink next onClick={() => this.changePageNext()} />
+        </PaginationItem>
+      )
     );
   };
 


### PR DESCRIPTION
## Status: 

:rocket: Ready

## Description
This PR improves the pagination buttons by disabling the previous button if user is on the first page, and disabling the next button if the user is on the last page.

Related issues: #259 
Related PRs: #<number>


## Screenshots

<img width="363" alt="Screen Shot 2019-05-27 at 8 10 55 PM" src="https://user-images.githubusercontent.com/22581791/58442788-a101cc00-80bb-11e9-98f8-e392dd18adb8.png">

<img width="356" alt="Screen Shot 2019-05-27 at 8 11 02 PM" src="https://user-images.githubusercontent.com/22581791/58442786-9e9f7200-80bb-11e9-98ae-8e01e54d262b.png">

