### PR TITLE
Adjust css to resolve overflow images of book images

### DIFF
--- a/frontend/src/styles/ReadingOlympics.scss
+++ b/frontend/src/styles/ReadingOlympics.scss
@@ -34,13 +34,15 @@
   }
   .book-card {
     transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+    min-width:250px;
   }
   .book-card:hover {
-    box-shadow: 0 14px 28px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.22);
+    box-shadow: 0 14px 28px rgba(214, 74, 74, 0.25), 0 10px 10px rgba(0, 0, 0, 0.22);
   }
 
   .book-image {
     max-height: 300px;
+    max-width: 100%;
     width: auto;
     border-radius: 10px;
     box-shadow: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23);


### PR DESCRIPTION
<!--
WELCOME TO OUR PULL REQUEST TEMPLATE! :partyparrot:
Not all sections apply, feel free to delete as appropriate.
-->

## Status: 
:rocket:


## Description
Added max-width:100% property of .book-image for frontend/src/styles/ReadingOlympics.scss
Added min-width:250px property of .book-card for frontend/src/styles/ReadingOlympics.scss

Related issues: #148 


## Screenshots
![Screen Shot 2019-06-22 at 12 21 07 PM](https://user-images.githubusercontent.com/29493389/59966278-21172800-94e8-11e9-8b28-1a15a1ced097.png)
