### PR TITLE
add reverse proxy for requests made to the /api endpoint

### DIFF
--- a/frontend/philareads.conf
+++ b/frontend/philareads.conf
@@ -1,8 +1,20 @@
+upstream docker_api_server {
+  server app:5000;
+}
+
 server {
   listen 80;
 
     location / {
       root /usr/share/nginx/html/;
     }
-}
 
+    location /api {
+      proxy_pass http://docker_api_server;
+      proxy_redirect off;
+      proxy_set_header   Host $host;
+      proxy_set_header   X-Real-IP $remote_addr;
+      proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header   X-Forwarded-Host $server_name;
+    }
+}


### PR DESCRIPTION
This was an oversight on my part with the production setup previously. 

## Status: 

:rocket: Ready

## Description
- sets up an upstream server to the docker container named 'app' on port
5000
- uses this upstream server as the proxy_pass for /api routes
- passes along header and host information as well

Related issues: #291 
Related PRs: #<number>