### PR TITLE
Make client depend on app when starting up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       context: ./frontend
     ports:
       - 80:80
+    depends_on:
+      - app
   app:
     restart: always
     build:


### PR DESCRIPTION
## Status:
🚀 

The prevents the nginx error `can't find upstream app:5000` by making sure that app is initiated before client